### PR TITLE
impl Lex directly on char and &'static str

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Note: This crate isn't published to crates.io yet, I'm still working on an initi
 ## Example
 
 ```rust
-use parsely::{char_if, token, Lex, Parse, ParseResult};
+use parsely::{char_if, Lex, Parse, ParseResult};
 
 #[derive(Debug, PartialEq)]
 pub struct Color {
@@ -33,7 +33,7 @@ fn hex_primary() -> impl Parse<Output = u8> {
 }
 
 fn hex_color(input: &str) -> ParseResult<Color> {
-    let (((red, green), blue), remaining) = token("#")
+    let (((red, green), blue), remaining) = "#"
         .skip_then(hex_primary().then(hex_primary()).then(hex_primary()))
         .parse(input)?;
 

--- a/examples/canonical_example.rs
+++ b/examples/canonical_example.rs
@@ -1,4 +1,4 @@
-use parsely::{char_if, token, Lex, Parse, ParseResult};
+use parsely::{char_if, Lex, Parse, ParseResult};
 
 #[derive(Debug, PartialEq)]
 pub struct Color {
@@ -20,7 +20,7 @@ fn hex_primary() -> impl Parse<Output = u8> {
 }
 
 fn hex_color(input: &str) -> ParseResult<Color> {
-    let (((red, green), blue), remaining) = token("#")
+    let (((red, green), blue), remaining) = "#"
         .skip_then(hex_primary().then(hex_primary()).then(hex_primary()))
         .parse(input)?;
 

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::BTreeMap, io::BufRead};
 
-use parsely::{ws, Lex, Parse, ParseResult};
+use parsely::{switch, ws, Lex, Parse, ParseResult};
 
 // first come all the types we parse into...
 
@@ -58,15 +58,15 @@ fn string() -> impl Parse<Output = String> {
 }
 
 fn escape() -> impl Parse<Output = char> {
-    '\\'.skip_then(
-        ('\\'.map(|_| '\\'))
-            .or('t'.map(|_| '\t'))
-            .or('n'.map(|_| '\n'))
-            .or('r'.map(|_| '\r'))
-            .or('b'.map(|_| '\x08'))
-            .or('f'.map(|_| '\x0c'))
-            .or('"'.map(|_| '"')),
-    )
+    '\\'.skip_then(switch([
+        ('\\', '\\'),
+        ('t', '\t'),
+        ('n', '\n'),
+        ('r', '\r'),
+        ('b', '\x08'),
+        ('f', '\x0c'),
+        ('"', '"'),
+    ]))
 }
 
 // note that fn as parser is used here (and for map) because returning `impl Parse<Output = Vec<Value>>` would create a "recursive opaque type"

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -387,3 +387,15 @@ where
         self(input)
     }
 }
+
+impl Lex for char {
+    fn lex<'i>(&self, input: &'i str) -> LexResult<'i> {
+        crate::lexer::char(*self).lex(input)
+    }
+}
+
+impl Lex for &'static str {
+    fn lex<'i>(&self, input: &'i str) -> LexResult<'i> {
+        crate::lexer::token(self).lex(input)
+    }
+}

--- a/src/lexer/char.rs
+++ b/src/lexer/char.rs
@@ -40,6 +40,24 @@ impl Lex for Char {
 /// assert_eq!(remaining, "bc");
 /// # Ok::<(), parsely::Error>(())
 /// ```
+///
+/// Note that using the [`char`](prim@char) primitive is equivalent to wrapping that char in [`char()`].
+///
+/// the above example can be shortened to:
+///
+/// ```
+/// use parsely::{char, Lex};
+/// // Note: the Lex trait must be in scope for this to work
+///
+/// let (output, remaining) = 'a'.lex("abc")?;
+/// assert_eq!(output, "a");
+/// assert_eq!(remaining, "bc");
+/// # Ok::<(), parsely::Error>(())
+/// ```
+///
+/// Using chars directly is preferred in the examples throughout this documentation.
+///
+/// See also [`token()`](crate::token) to match strings rather than single chars.
 pub fn char(char: char) -> Char {
     Char(char)
 }

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -85,6 +85,25 @@ impl<'p> Lex for Token<'p, CaseInsensitive> {
 /// # Ok::<(), parsely::Error>(())
 /// ```
 ///
+/// [`&'static str`](prim@str) literals impl [`Lex`] directly by wraping them in `token()`.
+///
+/// This means the above example can be shortened:
+///
+/// ```
+/// // the Lex trait must be in scope for this to work
+/// use parsely::Lex;
+/// # use parsely::char;
+///
+/// let (at, _) = char('@').lex("@ me")?;
+/// # let at_1 = at;
+/// let (at, _) = '@'.lex("@ me")?;
+/// # let at_2 = at;
+/// assert_eq!(at_1, at_2);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// Using strings directly is preferred in the examples throughout this documentation.
+///
 /// Map the output of a lexer to create a parser:
 ///
 /// ```

--- a/src/parser/switch.rs
+++ b/src/parser/switch.rs
@@ -1,4 +1,4 @@
-use crate::{token, Error, Lex, Parse};
+use crate::{Error, Lex, Parse};
 
 pub struct Switch<L, T, const N: usize> {
     items: [(L, T); N],
@@ -29,16 +29,16 @@ pub struct Switch<L, T, const N: usize> {
 ///     Quux,
 /// }
 ///
-/// let my_token_parser = token("foo").map(|_| MyTokens::Foo)
-///     .or(token("bar").map(|_| MyTokens::Bar))
-///     .or(token("baz").map(|_| MyTokens::Baz))
-///     .or(token("quux").map(|_| MyTokens::Quux));
+/// let my_token_parser = "foo".map(|_| MyTokens::Foo)
+///     .or("bar".map(|_| MyTokens::Bar))
+///     .or("baz".map(|_| MyTokens::Baz))
+///     .or("quux".map(|_| MyTokens::Quux));
 ///
 /// assert_eq!(my_token_parser.parse("foo 123")?, (MyTokens::Foo, " 123"));
 /// # Ok::<(), parsely::Error>(())
 /// ```
 ///
-/// The above is simplified by using `switch()` (note that str literals are accepted without token(), this is a special case for switch for convenience):
+/// The above is simplified by using `switch()`
 /// ```
 /// use parsely::{Lex, Parse, switch};
 ///
@@ -73,23 +73,6 @@ where
 
     fn parse<'i>(&self, input: &'i str) -> crate::ParseResult<'i, Self::Output> {
         for (lexer, output) in self.items.iter() {
-            if let Ok((_, remaining)) = lexer.lex(input) {
-                return Ok((output.clone(), remaining));
-            }
-        }
-        Err(Error::NoMatch)
-    }
-}
-
-impl<T, const N: usize> Parse for Switch<&'static str, T, N>
-where
-    T: Clone,
-{
-    type Output = T;
-
-    fn parse<'i>(&self, input: &'i str) -> crate::ParseResult<'i, Self::Output> {
-        for (s, output) in self.items.iter() {
-            let lexer = token(s);
             if let Ok((_, remaining)) = lexer.lex(input) {
                 return Ok((output.clone(), remaining));
             }


### PR DESCRIPTION
This was surprisingly easy. Since `Lex` deals with only `&str`, it's trivial to simply impl it directly.
I'm not too concerned by the implicit struct wrapping this uses, since neither `Token` nor `Char` allocate. 

This also includes a missing feature/fix of the json parsing example - it didn't parse `{"a": 1, "b": 2}` because it could only parse a single key-value pair per map. Whoops!